### PR TITLE
Improve store release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+.gitattributes export-ignore
+.github/ export-ignore
+Tests/ export-ignore
+.gitignore export-ignore
+.make.env export-ignore
+.php_cs.dist export-ignore
+.psh.yml.dist export-ignore
+before_install_plugin.sh export-ignore
+phpunit.xml export-ignore
+psh export-ignore

--- a/psh
+++ b/psh
@@ -1,1 +1,2 @@
-vendor/shopware/plugin-dev-tools/psh.phar
+#!/usr/bin/env sh
+./vendor/shopware/plugin-dev-tools/psh.phar "$@"


### PR DESCRIPTION
I replaced the dead symlink of psh with a shell script that can run the psh file it once referenced to. That is helpful when the released file is packed into an artifact without the dev vendor folder and later unpacked. The later unpacked file once packed a dead symlink and thus dies (or the packing of a dead symlink fails, depends on the point of failure).

As the store release deployment looks like a simple git archive I also added a `.gitattributes` file to exclude dev files from the release. Some of those files feel unused like the `.php_cs.dist` as the github actions just lint with `php -l` but maybe I am missing some of your internals and therefore did not change that.

Note from @jkrzefski is that the "optional dead symlink"-shell script could also run a `composer install` so in any case when `psh` is needed it is fetched first. I did not include this change as it'll be BC as this solution right now still fails when the `composer install --dev` did not happen before. I still appreciate his hint and like to mention it as a good addition to this here.